### PR TITLE
Update createPages to work when some .md files don't have category set.

### DIFF
--- a/packages/gatsby-plugin-categories/src/gatsby-node.js
+++ b/packages/gatsby-plugin-categories/src/gatsby-node.js
@@ -51,9 +51,9 @@ export const createPages = async (
 
   const categorySet = new Set();
 
-  pages.forEach(({ fields: { category } }) => {
-    if (category) {
-      categorySet.add(category);
+  pages.forEach(({ fields }) => {
+    if (fields && fields.category) {
+      categorySet.add(fields.category);
     }
   });
 


### PR DESCRIPTION
Fixes `TypeError: Cannot destructure property `category` of 'undefined' or 'null'.`