### PR TITLE
Update onCreateNode to work when some .md files don't have category set.

### DIFF
--- a/packages/gatsby-plugin-categories/src/gatsby-node.js
+++ b/packages/gatsby-plugin-categories/src/gatsby-node.js
@@ -15,7 +15,7 @@ export const onCreateNode = ({ node, actions }, pluginOptions) => {
       frontmatter: { category }
     } = node;
 
-    createNodeField({
+    category && createNodeField({
       node,
       name: "category",
       value: slugify(category, { ...slugOptions })


### PR DESCRIPTION
I must have made this change in my node_modules directory early on and forgot about it.  Sorry I didn't submit it with the earlier pull request.